### PR TITLE
Example of mult-string docstring for `notify()` function

### DIFF
--- a/saythanks/myemail.py
+++ b/saythanks/myemail.py
@@ -26,7 +26,11 @@ A KennethReitz project, now maintained by KGiSL Edu (info@kgisl.com).
 
 
 def notify(note, email_address):
-    """Use the note, an email template and sendgrid to deliver email to user."""
+    """Use the note contents and a template, build a 
+    formatted message. Use sendgrid to deliver the formatted 
+    message as an email to the user. 
+    """
+    
     try:
         # Say 'someone' if the byline is empty.
         who = note.byline or 'someone'

--- a/saythanks/myemail.py
+++ b/saythanks/myemail.py
@@ -30,7 +30,7 @@ def notify(note, email_address):
     formatted message. Use sendgrid to deliver the formatted 
     message as an email to the user. 
     """
-    
+
     try:
         # Say 'someone' if the byline is empty.
         who = note.byline or 'someone'


### PR DESCRIPTION
As suggested in https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings

1. Ending Triple quotes on newline.
2. Empty line after comment (not required for single line docstring).