### PR TITLE
 html emails are now saved in the db

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ gunicorn
 humanize
 itsdangerous
 Jinja2
+lxml==4.9.0
 MarkupSafe
 maya
 names


### PR DESCRIPTION
Fixed #227 

I have made it so that all the CSS is rendered only in the email and the plain HTML text is stored in the Database for viewing.

Note:
![Screenshot from 2022-06-20 23-06-22](https://user-images.githubusercontent.com/61784876/174712904-564bc806-bcc4-437c-83eb-80239e931e14.png)

Email:
![Screenshot from 2022-06-20 23-08-26](https://user-images.githubusercontent.com/61784876/174712935-d20298ca-ac0a-45cb-bb13-c705303234dd.png)

Saythanks inbox:

![Screenshot from 2022-06-21 09-31-12](https://user-images.githubusercontent.com/61784876/174713675-bb7f05cd-dd67-488b-9c40-16642e31c2b6.png)

- [x] I have added the issue number for which this pull request is created.

@Pavithratrdev, please let me know about this update.
