### PR TITLE
Bump Auth0 script to version 11.33, as new accounts are not working with older script

### DIFF
--- a/saythanks/templates/index.htm.j2
+++ b/saythanks/templates/index.htm.j2
@@ -37,7 +37,7 @@
       
         {# GitHub Auth button #}
 
-        <script src="https://cdn.auth0.com/js/lock/10.5/lock.min.js"></script>
+        <script src="https://cdn.auth0.com/js/lock/11.33/lock.min.js"></script>
         <script>
             var options_signup = {
               theme: {


### PR DESCRIPTION
Fixed #234 

Check (put an 'x' between the square brackets) everything which applies:

- [x] I have added the issue number for which this pull request is created.

@Pavithratrdev, please let me know about this update.
