### PR TITLE
Make logout button's position relative

### DIFF
--- a/saythanks/static/css/saythanks.css
+++ b/saythanks/static/css/saythanks.css
@@ -103,9 +103,7 @@ a.share {
 }
 
  .logoutLblPos{
-    position:absolute;
-    right:20px;
-    top: 25px;   
+    position:relative;
    }
    .github-corner:hover .octo-arm {
     animation: octocat-wave 560ms ease-in-out


### PR DESCRIPTION
Fixed #232 

Check (put an 'x' between the square brackets) everything which applies:

- [x] I have added the issue number for which this pull request is created.

Logout button's `display` was set to `absolute` and hence the overlapping. Made it to be `relative` to parent. 

@Pavithratrdev, @kgashok please let me know about this update.
