### PR TITLE
Fixed (email #293)=>  use absolute URLs in outgoing messages

### DIFF
--- a/saythanks/myemail.py
+++ b/saythanks/myemail.py
@@ -29,7 +29,7 @@ TEMPLATE = """<div>{}
 --{}
 <br>
 <br>
-The public URL for this note is <a clicktracking=off href="{}">here</a><br>. 
+The public URL for this note is <a clicktracking=off href="{}">here</a><br>
 <br>
 <br>
 =========

--- a/saythanks/myemail.py
+++ b/saythanks/myemail.py
@@ -29,8 +29,7 @@ TEMPLATE = """<div>{}
 --{}
 <br>
 <br>
-The public URL for this note is <a href="{}">here</a> <br>
-or {}. 
+The public URL for this note is <a clicktracking=off href="{}">here</a><br>. 
 <br>
 <br>
 =========


### PR DESCRIPTION
**Fixed #293** 

Check (put an 'x' between the square brackets) everything which applies:

- [✅] I have added the issue number for which this pull request was created.

@kgashok  @Pavithratrdev, _please let me know about this update!_
