### PR TITLE
The default placeholder text in bigger font

### DIFF
--- a/saythanks/templates/submit_note.htm.j2
+++ b/saythanks/templates/submit_note.htm.j2
@@ -10,13 +10,19 @@
         color: red;
         font-weight: bold;
       }
-    </style>
-    <style>
       #counter1 {
         color: red;
         font-weight: bold;
       }
+      /* Set font size and fixed font family for Toast UI Editor content */
+     .toastui-editor-defaultUI .toastui-editor-contents,
+     .toastui-editor-defaultUI .toastui-editor-md-preview-content,
+     .toastui-editor-defaultUI .ProseMirror {
+        font-size: 16px !important;
+        font-family: 'Fira Mono', 'Consolas', 'Menlo', 'Monaco', 'Liberation Mono', monospace !important;
+      }
     </style>
+     
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Fixed #280 

Check (put an 'x' between the square brackets) everything which applies:

- [x] I have added the issue number for which this pull request is created.

@Pavithratrdev, please let me know about this update.
