### PR TITLE
Sanitize HTML notes before storing as Markup-safe (fixes stored XSS, ref #399)

### DIFF
--- a/saythanks/core.py
+++ b/saythanks/core.py
@@ -403,7 +403,7 @@ def submit_note(inbox_id, topic):
 
     body = request.form['body']
     content_type = request.form['content-type']
-    byline = Markup(request.form['byline'])
+    byline = Markup(request.form['byline']).striptags()
 
     # If the user chooses to send an HTML email,
     # the contents of the HTML document will be sent
@@ -413,7 +413,23 @@ def submit_note(inbox_id, topic):
     topic = clean_topic(topic)
 
     if content_type == 'html':
-        body = Markup(body)
+        # Sanitize attacker-controlled HTML before marking it safe.
+        # The submission endpoint is unauthenticated and the stored body
+        # is later rendered through {{ note.body|safe }} in
+        # inbox.htm.j2 and also embedded into the HTML email sent to
+        # the inbox owner (myemail.py). Without sanitization a POST
+        # with content-type=html and body=<script>...</script> stores
+        # an exploit that fires when the owner opens /inbox or the
+        # notification email — full session takeover via document.cookie
+        # since the Auth0 cookies are not HttpOnly.
+        from lxml_html_clean import Cleaner
+        cleaner = Cleaner(
+            scripts=True, javascript=True, embedded=True, frames=True,
+            forms=True, meta=True, links=False, page_structure=True,
+            processing_instructions=True, style=True,
+            safe_attrs_only=True, remove_unknown_tags=True,
+        )
+        body = Markup(cleaner.clean_html(body))
         # print("after markup", body)
         # Store the note first, so it gets a UUID
         submitted_note = inbox_db.submit_note(


### PR DESCRIPTION
Closes #399 (security finding I raised privately in that thread).

## What this fixes

`POST /to/<inbox_id>/submit` (unauthenticated) accepts `content-type=html` and stores the raw `body` wrapped in `flask.Markup()`. That value is later rendered through `{{ note.body|safe }}` in `inbox.htm.j2`, and embedded raw into the HTML email template in `myemail.py`. The net effect is a **stored XSS** that anyone can plant in any public inbox slug — and that fires in the owner's browser (and mail client) the next time they open `/inbox` or the notification email.

The fix runs the HTML through `lxml_html_clean.Cleaner` (already a dependency, see `requirements.txt`) before wrapping it in `Markup()`. After this, stored bodies can no longer carry `<script>`, event handlers (`onerror`, `onload`, …), `javascript:` URLs, embedded objects, forms, or style blocks. Normal markup (`<p>`, `<b>`, `<i>`, links) is preserved.

Also fixes a smaller XSS via `byline`: the `html` branch was storing the raw `Markup`-wrapped byline, so `{{ note.byline }}` rendered attacker-supplied tags. The `markdown` branch already calls `.striptags()`; this PR makes the `html` branch consistent.

## Test plan

Sanitizer behaviour (quick checks I ran against the Cleaner config used here):

| Input | Stored output |
|---|---|
| `<script>alert(1)</script>` | `<div></div>` |
| `<img src=x onerror="alert(1)">` | `<img src="x">` |
| `<svg onload=alert(1)>` | `<svg></svg>` |
| `<a href="javascript:alert(1)">click</a>` | `<a href="">click</a>` |
| `<p>hello <b>world</b></p>` | `<p>hello <b>world</b></p>` (unchanged) |

So legitimate "rich text" notes still render normally.

## Ask: please merge + deploy ASAP

The live deployment at https://saythanks.io is still vulnerable as of this PR. 
I'll send the full advisory / impact analysis / PoC to a maintainer privately as soon as a contact is published — but the patch itself is small and self-contained, so the fastest mitigation is to land this and redeploy.

Happy to iterate on the Cleaner config if you'd like a stricter or looser allow-list.
