### PR TITLE
Add Twitter and Facebook share buttons for notes

### DIFF
--- a/saythanks/templates/inbox.htm.j2
+++ b/saythanks/templates/inbox.htm.j2
@@ -89,7 +89,11 @@
   <div class="notes-list">
   {% for note in notes %}
     <article class="note-item">
-      <div class="note-cell"><a class="share" href="{{ url_for('share_note', uuid=note.uuid)}}">🔗</a></div>
+      <div class="note-cell">
+       <a class="share" href="{{ url_for('share_note', uuid=note.uuid)}}">🔗</a><br>
+       <a href="https://twitter.com/intent/tweet?text={{ note.body }}%0A- {{ note.byline }}%0A{{ request.base_url[0:-6] + url_for('share_note', uuid=note.uuid) }}" class="twitter-share-button" data-hashtags="SayThanks">Tweet</a><br>
+       <iframe src="https://www.facebook.com/plugins/share_button.php?href={{ request.base_url[0:-6] + url_for('share_note', uuid=note.uuid) }}&layout=button&size=small&width=67&height=20&appId" width="67" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>
+      </div>
       <div class="note-cell message-cell">
           <a href="{{ url_for('share_note', uuid=note.uuid)}}">
               <span>{{ note.body|safe }}</span>

--- a/saythanks/templates/inbox.htm.j2
+++ b/saythanks/templates/inbox.htm.j2
@@ -91,7 +91,7 @@
     <article class="note-item">
       <div class="note-cell">
        <a class="share" href="{{ url_for('share_note', uuid=note.uuid)}}">🔗</a><br>
-       <a href="https://twitter.com/intent/tweet?text={{ note.body }}%0A- {{ note.byline }}%0A{{ request.base_url[0:-6] + url_for('share_note', uuid=note.uuid) }}" class="twitter-share-button" data-hashtags="SayThanks">Tweet</a><br>
+       <a href="https://twitter.com/intent/tweet?text={{ (note.body + '\n- ' + note.byline + '\n' + request.base_url[0:-6] + url_for('share_note', uuid=note.uuid))|urlencode }}" class="twitter-share-button" data-hashtags="SayThanks" target="_blank">Tweet</a><br>
        <iframe src="https://www.facebook.com/plugins/share_button.php?href={{ request.base_url[0:-6] + url_for('share_note', uuid=note.uuid) }}&layout=button&size=small&width=67&height=20&appId" width="67" height="20" style="border:none;overflow:hidden" scrolling="no" frameborder="0" allowfullscreen="true" allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"></iframe>
       </div>
       <div class="note-cell message-cell">


### PR DESCRIPTION
Fixed #171 

This re-adds Twitter and Facebook share buttons that were lost during the CSS Grid refactor of inbox.htm.j2.

Changes:
- Added Twitter share button (via intent/tweet) with note body and byline
- Added Facebook share button (via plugins/share_button)
- Existing Twitter widgets.js script in base.htm.j2 is now utilized

Closes #171