### PR TITLE
ci: fix GitHub Actions workflows for PRs

### DIFF
--- a/.github/workflows/autopep8.yml
+++ b/.github/workflows/autopep8.yml
@@ -12,10 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        # Make sure the actual branch is checked out when running on pull requests
-        ref: ${{ github.head_ref }}
+    - uses: actions/checkout@v4
     - uses: creyD/action_autopep8@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/jsformat.yml
+++ b/.github/workflows/jsformat.yml
@@ -13,10 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        # Make sure the actual branch is checked out when running on pull requests
-        ref: ${{ github.head_ref }}
+      uses: actions/checkout@v4
 
     - name: Prettify code
       uses: creyD/prettier_action@v3.1
@@ -25,4 +22,3 @@ jobs:
         prettier_options: --write **/*.{js,md}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  


### PR DESCRIPTION
## Summary

Fixes failing GitHub Actions workflows on pull requests.

## Changes

- **`autopep8.yml`**: Updated `actions/checkout` from v2 to v4, removed unnecessary `ref` parameter
- **`jsformat.yml`**: Updated `actions/checkout` from v2 to v4, removed unnecessary `ref` parameter

## Root Cause

The workflows used `ref: ${{ github.head_ref }}` which is redundant and causes failures. The `actions/checkout` action already automatically detects and checks out the correct branch for pull requests.

Additionally, both workflows were using the outdated `actions/checkout@v2` instead of the current `v4`.

## Testing

After this change, the workflows should run successfully on both push and pull request events.

Fixes #250