### PR TITLE
Replace Facebook share link with styled button icon

### DIFF
--- a/saythanks/templates/inbox.htm.j2
+++ b/saythanks/templates/inbox.htm.j2
@@ -112,9 +112,12 @@
           ~ '&quote=' ~ fb_quote
           ~ '&redirect_uri=' ~ fb_url|urlencode %}
 
-       <a  target="_blank" href="{{ share_href }}" class="fb-share" rel="noopener">
-        Share on Facebook
-       </a>
+       <a target="_blank" href="{{ share_href }}" class="fb-share" rel="noopener" aria-label="Share on Facebook">
+  <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
+    <path d="M22 12.06C22 6.48 17.52 2 11.94 2 6.36 2 1.88 6.48 1.88 12.06c0 5.02 3.66 9.19 8.44 9.94v-7.03H7.9v-2.91h2.42V9.91c0-2.39 1.42-3.71 3.6-3.71 1.04 0 2.13.19 2.13.19v2.34h-1.2c-1.18 0-1.55.73-1.55 1.48v1.78h2.64l-.42 2.91h-2.22V22c4.78-.75 8.44-4.92 8.44-9.94z"/>
+  </svg>
+  Facebook
+</a>
       </div>
       <div class="note-cell message-cell">
           <a href="{{ url_for('share_note', uuid=note.uuid)}}">
@@ -213,6 +216,24 @@
   height: auto !important;
   object-fit: contain;
   margin: 10px auto;
+}
+
+.fb-share {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background-color: #1877F2;
+  color: #fff;
+  padding: 0.3em 0.9em;
+  border-radius: 9999px;
+  font-size: 0.8em;
+  font-weight: bold;
+  text-decoration: none;
+  line-height: 1.4;
+}
+.fb-share:hover {
+  background-color: #145dbf;
+  text-decoration: none;
 }
 </style>
 


### PR DESCRIPTION
Fixed #427 

Check (put an 'x' between the square brackets) everything which applies:

- [x] I have added the issue number for which this pull request is created.

@Pavithratrdev, please let me know about this update.
