### PR TITLE
Fix trailing whitespace in core.py (#444)

### DIFF
--- a/saythanks/core.py
+++ b/saythanks/core.py
@@ -159,7 +159,7 @@ def requires_auth(f):
 # ------------------
 
 @app.route("/robots.txt")
-def robots():    
+def robots():
     return send_from_directory("static", "robots.txt")
 
 


### PR DESCRIPTION
Removes the trailing whitespace after `def robots():` in `saythanks/core.py` (line 162), as flagged by DeepSource in #444.

Fixes #444