### PR TITLE
Use Meta Share Dialog (FB.ui) for Facebook sharing

### DIFF
--- a/saythanks/templates/inbox.htm.j2
+++ b/saythanks/templates/inbox.htm.j2
@@ -104,19 +104,11 @@
           </svg>
         </a><br>
 
-        {% set fb_quote = (note.body|strip_html ~ ' — ' ~ note.byline)|urlencode %}
-        {% set share_href =
-           'https://www.facebook.com/dialog/share'
-           ~ '?app_id=' ~ config['FB_APP_ID']
-           ~ '&display=popup'
-           ~ '&href=' ~ share_url_abs|urlencode
-           ~ '&quote=' ~ fb_quote
-           ~ '&redirect_uri=' ~ share_url_abs|urlencode %}
-
         <a class="fb-share"
            target="_blank" rel="noopener"
            aria-label="Share on Facebook" title="Share on Facebook"
-           href="{{ share_href }}">
+           href="{{ share_url_abs }}"
+           data-quote="{{ note.body|strip_html ~ ' — ' ~ note.byline }}">
           <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true">
             <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99
                      4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007
@@ -258,10 +250,30 @@ document.addEventListener("DOMContentLoaded", function () {
   };
 });
 
+window.fbAsyncInit = function () {
+  FB.init({
+    appId: '{{ config['FB_APP_ID'] }}',
+    version: 'v26.0'
+  });
+};
+
+(function (d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) { return; }
+  js = d.createElement(s); js.id = id;
+  js.src = 'https://connect.facebook.net/en_US/sdk.js';
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));
+
 document.querySelectorAll('a.fb-share').forEach(function (a) {
   a.addEventListener('click', function (e) {
+    if (typeof FB === 'undefined') { return; }
     e.preventDefault();
-    window.open(a.href, 'fbshare', 'width=600,height=540,noopener');
+    var options = { method: 'share', href: a.href };
+    if (a.dataset.quote) {
+      options.quote = a.dataset.quote;
+    }
+    FB.ui(options, function (response) {});
   });
 });
 

--- a/saythanks/templates/inbox.htm.j2
+++ b/saythanks/templates/inbox.htm.j2
@@ -250,6 +250,8 @@ document.addEventListener("DOMContentLoaded", function () {
   };
 });
 
+var sdkFailed = false;
+
 window.fbAsyncInit = function () {
   FB.init({
     appId: '{{ config['FB_APP_ID'] }}',
@@ -261,14 +263,21 @@ window.fbAsyncInit = function () {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) { return; }
   js = d.createElement(s); js.id = id;
+  js.onerror = function () { sdkFailed = true; };
   js.src = 'https://connect.facebook.net/en_US/sdk.js';
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));
 
 document.querySelectorAll('a.fb-share').forEach(function (a) {
   a.addEventListener('click', function (e) {
-    if (typeof FB === 'undefined') { return; }
     e.preventDefault();
+    if (typeof FB === 'undefined' || sdkFailed) {
+      window.open(
+        'https://www.facebook.com/dialog/share?app_id={{ config['FB_APP_ID'] }}&display=popup&href=' + encodeURIComponent(a.href) + '&redirect_uri=' + encodeURIComponent(a.href),
+        '_blank', 'noopener'
+      );
+      return;
+    }
     var options = { method: 'share', href: a.href };
     if (a.dataset.quote) {
       options.quote = a.dataset.quote;

--- a/saythanks/templates/share_note.htm.j2
+++ b/saythanks/templates/share_note.htm.j2
@@ -32,12 +32,6 @@
     {% set tweet_text = note.body|strip_html
         ~ '\n\n- ' ~ note.byline
         ~ '\n\n' ~ share_url %}
-    {% set fb_params = {
-      'app_id': config['FB_APP_ID'],
-      'display': 'popup',
-      'href': share_url,
-      'redirect_uri': share_url
-    } %}
 
   <a class="x-share" target="_blank" rel="noopener"
      aria-label="Share on X" title="Share on X"
@@ -52,7 +46,7 @@
 
   <a class="fb-share" target="_blank" rel="noopener"
      aria-label="Share on Facebook" title="Share on Facebook"
-     href="https://www.facebook.com/dialog/share?{{ fb_params|urlencode }}">
+     href="{{ share_url }}">
     <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor"
          aria-hidden="true">
       <path d="M13.5 22v-8h2.7l.4-3.2h-3.1V8.7c0-.9.3-1.6 1.6-1.6h1.6V4.2
@@ -96,10 +90,29 @@
   countDirection: 'up'
 });
 
+window.fbAsyncInit = function () {
+  FB.init({
+    appId: '{{ config['FB_APP_ID'] }}',
+    version: 'v26.0'
+  });
+};
+
+(function (d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) { return; }
+  js = d.createElement(s); js.id = id;
+  js.src = 'https://connect.facebook.net/en_US/sdk.js';
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));
+
 document.querySelectorAll('a.fb-share').forEach(function (a) {
   a.addEventListener('click', function (e) {
+    if (typeof FB === 'undefined') { return; }
     e.preventDefault();
-    window.open(a.href, 'fbshare', 'width=600,height=540,noopener');
+    FB.ui({
+      method: 'share',
+      href: a.href
+    }, function (response) {});
   });
 });
 </script>

--- a/saythanks/templates/share_note.htm.j2
+++ b/saythanks/templates/share_note.htm.j2
@@ -90,6 +90,8 @@
   countDirection: 'up'
 });
 
+var sdkFailed = false;
+
 window.fbAsyncInit = function () {
   FB.init({
     appId: '{{ config['FB_APP_ID'] }}',
@@ -101,14 +103,21 @@ window.fbAsyncInit = function () {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) { return; }
   js = d.createElement(s); js.id = id;
+  js.onerror = function () { sdkFailed = true; };
   js.src = 'https://connect.facebook.net/en_US/sdk.js';
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));
 
 document.querySelectorAll('a.fb-share').forEach(function (a) {
   a.addEventListener('click', function (e) {
-    if (typeof FB === 'undefined') { return; }
     e.preventDefault();
+    if (typeof FB === 'undefined' || sdkFailed) {
+      window.open(
+        'https://www.facebook.com/dialog/share?app_id={{ config['FB_APP_ID'] }}&display=popup&href=' + encodeURIComponent(a.href) + '&redirect_uri=' + encodeURIComponent(a.href),
+        '_blank', 'noopener'
+      );
+      return;
+    }
     FB.ui({
       method: 'share',
       href: a.href


### PR DESCRIPTION
Fixes #429

## Summary
Replaces the deprecated `https://www.facebook.com/dialog/share?display=popup` URL + `window.open` approach with the official **Meta Share Dialog** (Facebook JavaScript SDK, `FB.ui({ method: 'share', href })`) on both the inbox and thank-you note templates.

- Adds the SDK loader and `window.fbAsyncInit` → `FB.init({ appId, version: 'v26.0' })`
- Share buttons call `FB.ui({ method: 'share', href: <note-url> }, callback)`; no custom popup handling (the SDK manages popups/app handoff natively)
- Quote text on the inbox page is preserved via a `data-quote` attribute passed as `options.quote` — treated as optional/legacy, since current Share Dialog docs no longer list it (harmless if ignored by Facebook; the `og:` tags control the preview card)

## SDK-load-failure fallback
When the SDK fails to load (e.g., Firefox's Enhanced Tracking Protection blocks `connect.facebook.net`, CDN outage), the click falls back to the documented URL-redirection dialog (`dialog/share?app_id=…&display=popup&href=…&redirect_uri=…`) opened in a new tab, so the button is never a silent no-op. Detected via the loader script's `onerror` plus a `typeof FB === 'undefined'` guard.

## Validation performed
- 8 automated scenarios (desktop/mobile × note/inbox × instrumented/real): SDK loads once, `FB.init` succeeds with the app id, `FB.ui` receives the correct `href` (and `quote` on inbox)
- **SDK normal**: Share Dialog opens via the SDK (`facebook.com/v26.0/dialog/share`, `sdk=joey`) ✓
- **SDK blocked (ETP simulated)**: fallback dialog URL opens with the correct `app_id`/`href` ✓
- **Desktop web**: Share Dialog opens in a popup ✓
- **Mobile with Facebook app installed**: hands off to the Facebook app ✓
- **Mobile without the Facebook app** (the original bug): the dialog opens as a popup at `m.facebook.com/v26.0/dialog/share` with the correct `app_id`, `href`, `display=touch` — confirmed both in emulation and on a real phone
- The final click-through (login → dialog → Post) can **only be verified in production**: Facebook restricts the Share Dialog to the app's configured domains, so localhost/tunnel origins show "The domain of this URL isn't included in the app's domains" regardless of the code. `https://saythanks.io` is already a configured app domain.