### PR TITLE
Fix FLK-E501 line length violations

### DIFF
--- a/saythanks/core.py
+++ b/saythanks/core.py
@@ -398,7 +398,8 @@ def submit_note(inbox_id, topic):
     audio_file = request.files.get('audio')
     audio_filename = None
 
-    if audio_file and audio_file.filename:   # empty FileStorage is truthy — guard on filename
+    # Empty FileStorage is truthy, so guard on filename.
+    if audio_file and audio_file.filename:
         upload_folder = os.path.join(app.static_folder, 'recordings')
         os.makedirs(upload_folder, exist_ok=True)
         # Add a timestamp to the filename to ensure uniqueness

--- a/saythanks/storage.py
+++ b/saythanks/storage.py
@@ -65,8 +65,12 @@ class Note:
 
     def __repr__(self):
         """Return a short representation for debugging."""
-        return f'<Note size={len(self.body)}>' if self.body else '<Note (empty)>'.strip()
+        if self.body:
+            return f"<Note size={len(self.body)}>"
 
+        return "<Note (empty)>"
+
+    
     @classmethod
     def fetch(cls, uuid):
         """Retrieve a Note from the database by UUID.


### PR DESCRIPTION
## Summary

This PR fixes the two FLK-E501 line length violations reported by DeepSource by:

- Moving the inline comment above the `if audio_file and audio_file.filename` statement in `core.py`.
- Refactoring the `Note.__repr__()` method into a multi-line implementation to satisfy the configured maximum line length.

Fixes #443