### PR TITLE
Fix: saythanks/static/css/saythanks.css

### DIFF
--- a/saythanks/static/css/saythanks.css
+++ b/saythanks/static/css/saythanks.css
@@ -273,7 +273,7 @@ a.share {
 }
 
 .message-cell a:hover {
-  color: #1EAEDB; /* Change text color on hover */
+  color: #3ac025; /* Change text color on hover */
   text-decoration: none; /* No underline on hover */
 }
 


### PR DESCRIPTION
The `.message-cell a:hover` rule uses `#1EAEDB` (light blue), which overrides the app's original green theme used elsewhere (e.g., `.button-primary`, `.green`, `a`). This should be reverted to the green color to match the original theme.

_This change was drafted with AI assistance and reviewed by a human before this PR was opened._