### PR TITLE
Fix upload progress starting at 100%

### DIFF
--- a/saythanks/templates/submit_note.htm.j2
+++ b/saythanks/templates/submit_note.htm.j2
@@ -182,6 +182,7 @@
       if (e.lengthComputable) 
         recordingStatus.innerText = 'Uploading… ' + Math.round(e.loaded / e.total * 100) + '%';
     };
+    recordingStatus.innerText = 'Uploading… 0%';
     request.send(formData);  
   });
 

--- a/tests/test_submit_note_template.py
+++ b/tests/test_submit_note_template.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+from io import open
+import os
+
+
+def test_upload_progress_starts_at_zero_before_request_is_sent():
+    repository_root = os.path.dirname(os.path.dirname(__file__))
+    template_path = os.path.join(
+        repository_root, 'saythanks', 'templates', 'submit_note.htm.j2'
+    )
+
+    with open(template_path, encoding='utf-8') as template_file:
+        template = template_file.read()
+
+    submit_start = template.index("form.addEventListener('submit'")
+    submit_handler = template[submit_start:]
+    initial_status = u"recordingStatus.innerText = 'Uploading… 0%';"
+    send_request = 'request.send(formData);'
+    progress_update = (
+        u"recordingStatus.innerText = 'Uploading… ' + "
+        u"Math.round(e.loaded / e.total * 100) + '%';"
+    )
+
+    assert initial_status in submit_handler
+    assert progress_update in submit_handler
+    initial_position = submit_handler.index(initial_status)
+    send_position = submit_handler.index(send_request)
+    assert initial_position < send_position


### PR DESCRIPTION
Fixed #492

- [x] I have added the issue number for which this pull request is created.

## What changed

Set the upload status to `Uploading… 0%` immediately before `XMLHttpRequest.send()`. Computable upload progress events continue to replace it with the rounded live percentage through 100%.

Added a focused template regression that verifies the zero state exists before the request is sent and that the existing progress calculation remains present.

## Validation

- `uv run --with pytest --with flake8 pytest -q tests`
- `uv run --with flake8 flake8 tests/test_submit_note_template.py`
- Jinja template parse
- `git diff --check`

Implemented with Codex agent assistance; I reviewed the issue scope, implementation, tests, and final diff.