### PR TITLE
fix: avoid submit button name collision

### DIFF
--- a/saythanks/templates/submit_note.htm.j2
+++ b/saythanks/templates/submit_note.htm.j2
@@ -117,9 +117,9 @@
 
 <!-- Button -->
 <div class="form-group">
-  <label class="col-md-4 control-label" for="submit"></label>
+  <label class="col-md-4 control-label" for="submit-note"></label>
   <div class="col-md-4">
-    <button id="submit" name="submit" class="btn button-primary" type="submit">Send Note <img id="eve-send" src="{{ url_for('static', filename='images/owly.svg') }}" alt="Eve the Owl"> </button>
+    <button id="submit-note" class="btn button-primary" type="submit">Send Note <img id="eve-send" src="{{ url_for('static', filename='images/owly.svg') }}" alt="Eve the Owl"> </button>
   </div>
 </div>
 <h2>🝐</h2>
@@ -154,7 +154,7 @@
   });
 
   var form = document.getElementById("thankyou-note-form");
-  var submitBtn = document.getElementById("submit");  
+  var submitBtn = document.getElementById("submit-note");
   
   form.addEventListener('submit', (event) => {
     event.preventDefault();

--- a/tests/test_submit_note_template.py
+++ b/tests/test_submit_note_template.py
@@ -4,8 +4,8 @@ from io import open
 import os
 
 
-def test_upload_progress_starts_at_zero_before_request_is_sent():
-    """Ensure the upload indicator begins at 0% before the form request is sent."""
+def test_upload_status_is_set_before_send():
+    """Ensure upload status is initialized before sending."""
     repository_root = os.path.dirname(os.path.dirname(__file__))
     template_path = os.path.join(
         repository_root, 'saythanks', 'templates', 'submit_note.htm.j2'
@@ -28,3 +28,19 @@ def test_upload_progress_starts_at_zero_before_request_is_sent():
     initial_position = submit_handler.index(initial_status)
     send_position = submit_handler.index(send_request)
     assert initial_position < send_position
+
+
+def test_submit_button_does_not_shadow_native_form_submit():
+    """Ensure the form's submit method is not clobbered by its button."""
+    repository_root = os.path.dirname(os.path.dirname(__file__))
+    template_path = os.path.join(
+        repository_root, 'saythanks', 'templates', 'submit_note.htm.j2'
+    )
+
+    with open(template_path, encoding='utf-8') as template_file:
+        template = template_file.read()
+
+    assert 'id="submit"' not in template
+    assert 'name="submit"' not in template
+    assert 'id="submit-note"' in template
+    assert 'document.getElementById("submit-note")' in template


### PR DESCRIPTION
Fixes #499

## Summary

- Rename the submit button ID and remove its `name="submit"` attribute so it no longer shadows `HTMLFormElement.submit`.
- Keep the JavaScript button lookup aligned with the new ID.
- Add regression coverage for the non-clobbering markup.

## Tests

- `.venv/bin/python -m pytest -q tests` (2 passed)
- `.venv/bin/flake8 tests/test_submit_note_template.py`
