### PR TITLE
Implemented set of pre-defined email templates for users + live preview of email before send.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This simple button/link can be added to READMEs and project documentation.
 The author can then enjoy a nice inbox (ideally) filled with very small, thoughtful messages from the happy users of the software they enjoy to toil over.
 
 ## Recent Improvements
+- **Live Email Preview + Templates:** Added pre-defined templates for users to send. Users can now view their email as a live preview of what will be sent to the recipient before sending the actual email. This change addresses UX demands and adds quality-of-life functionality for the user.
 
 - **Email Delivery Provider Updated:** Migrated transactional email delivery from SendGrid to MailerSend for improved deliverability, modern API support, and more reliable service. This change addresses recent deliverability issues and leverages MailerSend’s robust features for transactional messaging.
 - Learn more here (https://github.com/mailersend/mailersend-python?tab=readme-ov-file#send-a-template-based-email)

--- a/saythanks/core.py
+++ b/saythanks/core.py
@@ -16,6 +16,7 @@ import time  # Added to handle timestamping for audio filenames
 from .version import get_version
 from .utils import strip_html
 from .logging_config import configure_logging
+from .myemail import resolve_template_id
 
 from functools import wraps
 from flask import Flask, request, session, render_template, url_for
@@ -443,6 +444,7 @@ def submit_note(inbox_id, topic):
     audio_html = render_audio_html(audio_filename)
     body = request.form['body']
     content_type = request.form['content-type']
+    template_id = resolve_template_id(request.form.get('email_template'))
     byline = Markup(request.form['byline']).striptags()
     if session:
         email_address = session['profile']['email']
@@ -475,7 +477,8 @@ def submit_note(inbox_id, topic):
             safe_attrs_only=True, remove_unknown_tags=True,
         )
         body = Markup(html_cleaner.clean_html(body))
-        body = Markup(body + Markup(audio_html)) # ← now part of the stored body
+        email_body = body
+        body = Markup(body + Markup(audio_html))  # stored body includes audio
         # print("after markup", body)
         # Store the note first, so it gets a UUID
         submitted_note = inbox_db.submit_note(
@@ -483,7 +486,13 @@ def submit_note(inbox_id, topic):
         )
         if storage.Inbox.is_email_enabled(inbox_db.slug):
             # Now notify, so the note has a UUID for the public URL
-            submitted_note.notify(email_address, topic)   # ← no audio_path
+            submitted_note.notify(
+                email_address,
+                topic,
+                template_id=template_id,
+                audio_html=audio_html,
+                body=email_body,
+            )
         return redirect(url_for('thanks'))
     # Strip any HTML away.
 
@@ -496,6 +505,7 @@ def submit_note(inbox_id, topic):
     if not body and not audio_html:
         return redirect(url_for('thanks'))
 
+    email_body = body
     body = body + audio_html
 
     submitted_note = inbox_db.submit_note(
@@ -503,7 +513,13 @@ def submit_note(inbox_id, topic):
     )
     # Email the user the new note.
     if storage.Inbox.is_email_enabled(inbox_db.slug):
-        submitted_note.notify(email_address, topic)
+        submitted_note.notify(
+            email_address,
+            topic,
+            template_id=template_id,
+            audio_html=audio_html,
+            body=email_body,
+        )
 
     return redirect(url_for('thanks'))
 

--- a/saythanks/myemail.py
+++ b/saythanks/myemail.py
@@ -1,9 +1,12 @@
+import html
 import os
-import requests
-
-from mailersend import emails
+import re
+from string import Template
 from urllib.error import URLError
+
+import requests
 from flask import url_for, current_app
+from mailersend import emails
 
 # importing module
 import logging
@@ -24,17 +27,110 @@ if not mailersend_api_key:
 else:
     mailer = emails.NewEmail(mailersend_api_key)
 
-TEMPLATE = """<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:15px;line-height:1.5;color:#222;max-width:600px">
-<div style="margin:0 0 12px">{}</div>
-<div style="margin:0 0 12px;color:#555">--{}</div>
-<div style="margin:0 0 16px">The public URL for this note is <a clicktracking=off href="{}">here</a></div>
+DEFAULT_TEMPLATE = 'classic'
+
+_CLASSIC = """<div>$topic_block$body
+<br>
+<br>
+$audio_block--$byline
+<br>
+<br>
+The public URL for this note is <a clicktracking=off href="$note_url">here</a> <br>
+<br>
+<br>
+=========
+<br>
+<br>
+This note of gratitude was brought to you by SayThanks.io.
+<br>
+<br>
+A KennethReitz project, now maintained by KGiSL Edu (https://edu.kgisl.com).
+</div>
+"""
+
+_COMPACT = """<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:15px;line-height:1.5;color:#222;max-width:600px">
+$topic_block
+<div style="margin:0 0 12px">$body</div>
+$audio_block
+<div style="margin:0 0 12px;color:#555">--$byline</div>
+<div style="margin:0 0 16px">The public URL for this note is <a clicktracking=off href="$note_url">here</a></div>
 <hr style="border:0;border-top:1px solid #ddd;margin:16px 0">
 <div style="font-size:13px;color:#777;line-height:1.4">
 This note of gratitude was brought to you by SayThanks.io.<br>
 A KennethReitz project, now maintained by KGiSL Edu (<a clicktracking=off href="https://edu.kgisl.com">https://edu.kgisl.com</a>).
 </div>
 </div>
-""" 
+"""
+
+_LETTER = """<div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:15px;line-height:1.5;color:#222;max-width:600px">
+<div style="border:1px solid #e5e5e5;border-left:4px solid #1EAEDB;padding:16px 20px;background:#fff">
+<div style="font-size:12px;letter-spacing:0.04em;text-transform:uppercase;color:#1EAEDB;margin:0 0 12px">A note of gratitude</div>
+$topic_block
+<div style="margin:0 0 12px">$body</div>
+$audio_block
+<div style="margin:0 0 12px;color:#555">--$byline</div>
+<div>The public URL for this note is <a clicktracking=off href="$note_url">here</a></div>
+</div>
+<div style="font-size:12px;color:#888;line-height:1.4;margin:12px 4px 0">
+This note of gratitude was brought to you by SayThanks.io.<br>
+A KennethReitz project, now maintained by KGiSL Edu (<a clicktracking=off href="https://edu.kgisl.com">https://edu.kgisl.com</a>).
+</div>
+</div>
+"""
+
+TEMPLATES = {
+    'classic': Template(_CLASSIC),
+    'compact': Template(_COMPACT),
+    'letter': Template(_LETTER),
+}
+TEMPLATE_IDS = tuple(TEMPLATES)
+
+
+def resolve_template_id(template_id):
+    """Return a known template id, or Classic when the value is not allowed."""
+    if template_id in TEMPLATE_IDS:
+        return template_id
+    return DEFAULT_TEMPLATE
+
+
+def _topic_block(topic):
+    """Return a Ref: HTML fragment, or '' when topic is missing."""
+    if topic is None:
+        return ''
+    topic_text = str(topic).strip()
+    if not topic_text:
+        return ''
+    escaped = html.escape(topic_text, quote=True)
+    return (
+        '<div style="margin:0 0 12px"><strong>Ref:</strong> about '
+        f'{escaped}</div>'
+    )
+
+
+def render_email_html(
+    template_id,
+    *,
+    body,
+    byline,
+    note_url,
+    topic=None,
+    audio_html='',
+):
+    """Render one predefined notification-email layout.
+
+    `body` and `audio_html` are inserted as HTML. `byline`, `note_url`,
+    and `topic` are escaped.
+    """
+    chosen = resolve_template_id(template_id)
+    return TEMPLATES[chosen].safe_substitute(
+        body='' if body is None else str(body),
+        byline=html.escape('' if byline is None else str(byline), quote=True),
+        note_url=html.escape(
+            '' if note_url is None else str(note_url), quote=True
+        ),
+        topic_block=_topic_block(topic),
+        audio_block='' if not audio_html else str(audio_html),
+    )
 
 
 def _get_note_url(note):
@@ -47,7 +143,8 @@ def _get_note_url(note):
     - note: object with attribute `uuid`.
 
     Returns
-    - str: Absolute URL for the note if uuid is present, otherwise an empty string.
+    - str: Absolute URL for the note if uuid is present,
+      otherwise an empty string.
 
     Side effects
     - Logs an error if note.uuid is missing.
@@ -59,13 +156,33 @@ def _get_note_url(note):
         return url_for('share_note', uuid=note.uuid, _external=True)
 
 
-def _build_email_content(note, note_url, audio_html='', audio_text=''):
+def _plaintext_audio(audio_html):
+    """Extract a voice-note URL from the HTML snippet for the plaintext part."""
+    if not audio_html:
+        return ''
+    match = re.search(r'href="([^"]+)"', audio_html)
+    if not match:
+        return ''
+    return f"\n\nVoice Note: {match.group(1)}"
+
+
+def _build_email_content(
+    note,
+    note_url,
+    audio_html='',
+    template_id=None,
+    body=None,
+    topic=None,
+):
     """Assemble HTML and plaintext email bodies.
 
     Parameters
     - note: object with attributes `body` and `byline`.
     - note_url: public URL for the note (string).
     - audio_html: optional HTML snippet for audio (string).
+    - template_id: predefined layout id (unknown values fall back to classic).
+    - body: optional pre-audio HTML body; defaults to note.body.
+    - topic: optional topic string for a Ref: line in the HTML layout.
 
     Returns
     - tuple: (who, html_content, plaintext_content)
@@ -74,9 +191,18 @@ def _build_email_content(note, note_url, audio_html='', audio_text=''):
       - plaintext_content: plain text representation for fallback
     """
     who = note.byline or 'someone'
-    html_content = TEMPLATE.format(note.body, note.byline, note_url)
+    email_body = note.body if body is None else body
+    html_content = render_email_html(
+        template_id,
+        body=email_body,
+        byline=note.byline or '',
+        note_url=note_url,
+        topic=topic,
+        audio_html=audio_html or '',
+    )
     plaintext_content = (
-        f"{note.body}\n\n--{note.byline or ''}{audio_text}\n\n{note_url}"
+        f"{email_body}\n\n--{note.byline or ''}"
+        f"{_plaintext_audio(audio_html)}\n\n{note_url}"
     )
     return who, html_content, plaintext_content
 
@@ -117,20 +243,32 @@ def _send_email(email_address, subject, html_content, plaintext_content):
         return True
 
     if response.status_code == 202:
-        logger.error(f"Email queued successfully for delivery to {email_address}")
+        logger.error(
+            f"Email queued successfully for delivery to {email_address}"
+        )
         return True
     if response.status_code == 200:
         logger.info(f"Email sent successfully to {email_address}")
         return True
     if response.status_code >= 400:
-        error_text = response.text if hasattr(response, 'text') else 'Unknown error'
+        error_text = (
+            response.text if hasattr(response, 'text') else 'Unknown error'
+        )
         error_msg = f"MailerSend API error {response.status_code}: {error_text}"
         logger.error(error_msg)
 
     return True
 
 
-def notify(note, email_address, topic=None, audio_path=None):
+def notify(
+    note,
+    email_address,
+    topic=None,
+    audio_path=None,
+    template_id=None,
+    audio_html=None,
+    body=None,
+):
     """Send an email notification for a thank-you note.
 
     Orchestrates URL generation, optional audio handling, content assembly,
@@ -140,11 +278,15 @@ def notify(note, email_address, topic=None, audio_path=None):
     Parameters
     - note: note object (expects attributes `uuid`, `body`, `byline`)
     - email_address: recipient email address (string)
-    - topic: optional topic string used in the email subject
-    - audio_path: optional filename for an attached voice note
+    - topic: optional topic string used in the email subject and Ref: line
+    - audio_path: optional filename for an attached voice note (unused; kept
+      for callers that still pass it)
+    - template_id: predefined layout id (classic, compact, letter)
+    - audio_html: optional voice-note HTML for a separate email slot
+    - body: optional pre-audio HTML body; defaults to note.body
 
     Returns
-    - bool: True if the email was successfully submitted/queued, False on failure
+    - bool: True if the email was submitted/queued, False on failure
       or when MailerSend is not configured.
 
     Error handling
@@ -157,7 +299,14 @@ def notify(note, email_address, topic=None, audio_path=None):
 
     try:
         note_url = _get_note_url(note)
-        who, html_content, plaintext_content = _build_email_content(note, note_url)
+        who, html_content, plaintext_content = _build_email_content(
+            note,
+            note_url,
+            audio_html=audio_html or '',
+            template_id=template_id,
+            body=body,
+            topic=topic,
+        )
 
         subject = (
             f'saythanks.io: {who} sent a note!'
@@ -172,7 +321,8 @@ def notify(note, email_address, topic=None, audio_path=None):
     except requests.exceptions.ConnectionError as e:
         logger.error(f"Network connection error when sending email: {str(e)}")
         logger.error(
-            "Check your internet connection and MAILERSEND_API_KEY configuration"
+            "Check your internet connection and "
+            "MAILERSEND_API_KEY configuration"
         )
     except requests.exceptions.Timeout as e:
         logger.error(f"Timeout error when sending email: {str(e)}")
@@ -190,26 +340,3 @@ def notify(note, email_address, topic=None, audio_path=None):
         print(e)
 
     return False
-
-
-# Deprecated TEMPLATE for reference, kept for backward compatibility
-'''
-TEMPLATE = """<div>{}
-<br>
-<br>
---{}
-<br>
-<br>
-The public URL for this note is <a clicktracking=off href="{}">here</a> <br>
-<br>
-<br>
-=========
-<br>
-<br>
-This note of gratitude was brought to you by SayThanks.io.
-<br>
-<br>
-A KennethReitz project, now maintained by KGiSL Edu (https://edu.kgisl.com).
-</div>
-"""
-'''

--- a/saythanks/storage.py
+++ b/saythanks/storage.py
@@ -199,7 +199,15 @@ class Note:
         q = sqlalchemy.text("UPDATE notes SET archived = 't' WHERE uuid = :uuid")
         conn.execute(q, uuid=self.uuid)
 
-    def notify(self, email_address, topic=None, audio_path=None):
+    def notify(
+        self,
+        email_address,
+        topic=None,
+        audio_path=None,
+        template_id=None,
+        audio_html=None,
+        body=None,
+    ):
         """Send an email notification for this note.
 
         Delegates to myemail.notify.
@@ -208,8 +216,19 @@ class Note:
             email_address (str): Recipient email address.
             topic (str|None): Optional topic for subject line.
             audio_path (str|None): Optional audio filename to include.
+            template_id (str|None): Predefined email layout id.
+            audio_html (str|None): Voice-note HTML for a separate email slot.
+            body (str|None): Pre-audio HTML body; defaults to this note's body.
         """
-        myemail.notify(self, email_address, topic, audio_path)
+        myemail.notify(
+            self,
+            email_address,
+            topic,
+            audio_path,
+            template_id=template_id,
+            audio_html=audio_html,
+            body=body,
+        )
 
 
 class Inbox:

--- a/saythanks/templates/submit_note.htm.j2
+++ b/saythanks/templates/submit_note.htm.j2
@@ -18,10 +18,54 @@
       /* Set font size and fixed font family for Toast UI Editor content */
      .toastui-editor-defaultUI .toastui-editor-contents,
      .toastui-editor-defaultUI .toastui-editor-md-preview-content,
-     .toastui-editor-defaultUI .ProseMirror {
+      .toastui-editor-defaultUI .ProseMirror {
         font-size: 16px !important;
         font-family: 'Fira Mono', 'Consolas', 'Menlo', 'Monaco', 'Liberation Mono', monospace !important;
       }
+      .email-preview-label {
+        font-size: 0.9rem;
+        color: #555;
+        margin: 0.75rem 0 0.35rem;
+      }
+      .email-preview-frame {
+        max-width: 600px;
+        padding: 12px 14px;
+        background: #fff;
+        color: #222;
+        font-size: 15px;
+        line-height: 1.5;
+        border: 1px solid #ddd;
+      }
+      .email-preview--classic .email-preview-kicker { display: none; }
+      .email-preview--classic .email-preview-equals { display: block; margin: 16px 0; }
+      .email-preview--classic .email-preview-hr { display: none; }
+      .email-preview--compact .email-preview-frame {
+        font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      }
+      .email-preview--compact .email-preview-kicker { display: none; }
+      .email-preview--compact .email-preview-equals { display: none; }
+      .email-preview--compact .email-preview-hr {
+        display: block;
+        border: 0;
+        border-top: 1px solid #ddd;
+        margin: 16px 0;
+      }
+      .email-preview--letter .email-preview-card {
+        border: 1px solid #e5e5e5;
+        border-left: 4px solid #1EAEDB;
+        padding: 16px 20px;
+      }
+      .email-preview--letter .email-preview-kicker {
+        display: block;
+        font-size: 12px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #1EAEDB;
+        margin: 0 0 12px;
+      }
+      .email-preview--letter .email-preview-equals { display: none; }
+      .email-preview--letter .email-preview-hr { display: none; }
+      .email-preview-footer { font-size: 13px; color: #777; line-height: 1.4; }
     </style>
      
 {% endblock %}
@@ -39,7 +83,7 @@
 <form id="thankyou-note-form" class="form-horizontal"
       action="./{{ user|urlencode }}/submit{{ '/' ~ topic if topic else '' }}"
       method="post">
-<div class="form-row" style="display:flex; align-items:center; gap:1rem; flex-wrap:nowrap;">
+<div class="form-row" style="display:flex; align-items:center; gap:1rem; flex-wrap:wrap;">
   <label for="fontstyle" style="white-space:nowrap;">Font Style:</label>
   <select name="font_style" id="fontstyle" onchange="fontforinbox(this);">
     <option value="0">Regular</option>
@@ -48,6 +92,13 @@
     <option value="3">Tahoma</option>
     <option value="4">Georgia</option>
     <option value="5">Trebuchet MS</option>
+  </select>
+
+  <label for="email-template" style="white-space:nowrap;">Email layout:</label>
+  <select name="email_template" id="email-template">
+    <option value="classic" selected>Classic</option>
+    <option value="compact">Compact</option>
+    <option value="letter">Letter</option>
   </select>
 
   <fieldset aria-label="Content Type" style="border:0;padding:0;margin:0; display:flex; align-items:center; gap:0.75rem;">
@@ -108,7 +159,7 @@ thoughtful words, so far… (shoot for 42!)</h6>
 
 
 
-<h6>You have written <strong><span id=counter>0</span></strong>
+<h6>You have written <strong><span id=counter1>0</span></strong>
 thoughtful words, so far… (shoot for 42!)</h6>
 <!-- Text input-->
 <div class="form-group">
@@ -120,6 +171,30 @@ thoughtful words, so far… (shoot for 42!)</h6>
            class="u-full-width" name="byline" type="text"
            placeholder="{{ fake_name }}"
            class="form-control input-md">
+  </div>
+</div>
+
+<div class="email-preview-label">Email preview</div>
+<div id="email-preview" class="email-preview email-preview--classic">
+  <div class="email-preview-frame">
+    <div class="email-preview-card">
+      <div class="email-preview-kicker">A note of gratitude</div>
+      {% if topic %}
+      <div id="email-preview-ref"><strong>Ref:</strong>{{ topic }}</div>
+      {% endif %}
+      <div id="email-preview-body" style="white-space:pre-wrap;margin:0 0 12px"></div>
+      <div id="email-preview-audio" style="display:none;margin:0 0 12px">
+        <strong>🎧 Voice Note:</strong> Click to listen
+      </div>
+      <div id="email-preview-byline" style="color:#555;margin:0 0 12px">--</div>
+      <div>The public URL for this note is here</div>
+    </div>
+    <div class="email-preview-equals">=========</div>
+    <hr class="email-preview-hr">
+    <div class="email-preview-footer">
+      This note of gratitude was brought to you by SayThanks.io.<br>
+      A KennethReitz project, now maintained by KGiSL Edu (https://edu.kgisl.com).
+    </div>
   </div>
 </div>
 
@@ -161,7 +236,7 @@ thoughtful words, so far… (shoot for 42!)</h6>
       el: textArea,
       previewStyle: 'tab',
       height: '500px',
-      initialValue: `{% if topic %}### Ref:{{ topic }}\n{% endif %}Dear {{ user }},\nThank you for...`
+      initialValue: `Dear {{ user }},\nThank you for...`
   });
 
   var form = document.getElementById("thankyou-note-form");
@@ -213,6 +288,7 @@ thoughtful words, so far… (shoot for 42!)</h6>
       counter.style.color = "red";
       counter1.style.color = "red";
     }
+    updateEmailPreviewContent();
   });
 
   document.querySelectorAll('.suggestion-btn').forEach(function(btn) {
@@ -245,6 +321,7 @@ thoughtful words, so far… (shoot for 42!)</h6>
     if (fileName) {
       recordingStatus.innerText += ` Selected file: ${fileName}`;
     }
+    updateEmailPreviewContent();
   }
 
   audioFileInput.addEventListener('change', () => {
@@ -315,6 +392,37 @@ thoughtful words, so far… (shoot for 42!)</h6>
       recordBtn.innerText = '🗣️ Say Something!';
     }
   });
+
+
+  var layoutSelect = document.getElementById('email-template');
+  var preview = document.getElementById('email-preview');
+  var bylineInput = document.getElementById('byline');
+
+  function applyEmailPreviewLayout() {
+    var id = layoutSelect.value;
+    if (id !== 'compact' && id !== 'letter') {
+      id = 'classic';
+    }
+    preview.className = 'email-preview email-preview--' + id;
+  }
+
+  function updateEmailPreviewContent() {
+    var bodyEl = document.getElementById('email-preview-body');
+    var bylineEl = document.getElementById('email-preview-byline');
+    var audioEl = document.getElementById('email-preview-audio');
+    if (!bodyEl || !bylineEl || !audioEl) {
+      return;
+    }
+    bodyEl.textContent = editor.getMarkdown();
+    bylineEl.textContent = '--' + (bylineInput.value || '');
+    var hasAudio = !!(audioBlob || (audioFileInput && audioFileInput.files.length));
+    audioEl.style.display = hasAudio ? 'block' : 'none';
+  }
+
+  layoutSelect.addEventListener('change', applyEmailPreviewLayout);
+  bylineInput.addEventListener('input', updateEmailPreviewContent);
+  applyEmailPreviewLayout();
+  updateEmailPreviewContent();
 
 
 </script>

--- a/saythanks/templates/submit_note.htm.j2
+++ b/saythanks/templates/submit_note.htm.j2
@@ -22,10 +22,20 @@
         font-size: 16px !important;
         font-family: 'Fira Mono', 'Consolas', 'Menlo', 'Monaco', 'Liberation Mono', monospace !important;
       }
-      .email-preview-label {
-        font-size: 0.9rem;
-        color: #555;
-        margin: 0.75rem 0 0.35rem;
+      #editor .toastui-editor-md-preview {
+        overflow: auto;
+        padding: 12px 14px;
+      }
+      #editor .toastui-editor-md-preview:has(.email-preview--letter) {
+        padding: 8px;
+      }
+      .email-preview-card .toastui-editor-contents {
+        margin: 0 0 12px;
+      }
+      .toastui-editor-defaultUI .email-preview--compact .toastui-editor-contents,
+      .toastui-editor-defaultUI .email-preview--letter .toastui-editor-contents {
+        font-size: 15px !important;
+        font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif !important;
       }
       .email-preview-frame {
         max-width: 600px;
@@ -94,7 +104,7 @@
     <option value="5">Trebuchet MS</option>
   </select>
 
-  <label for="email-template" style="white-space:nowrap;">Email layout:</label>
+  <label for="email-template" style="white-space:nowrap;">Layout:</label>
   <select name="email_template" id="email-template">
     <option value="classic" selected>Classic</option>
     <option value="compact">Compact</option>
@@ -174,7 +184,7 @@ thoughtful words, so far… (shoot for 42!)</h6>
   </div>
 </div>
 
-<div class="email-preview-label">Email preview</div>
+<template id="email-preview-template">
 <div id="email-preview" class="email-preview email-preview--classic">
   <div class="email-preview-frame">
     <div class="email-preview-card">
@@ -182,7 +192,6 @@ thoughtful words, so far… (shoot for 42!)</h6>
       {% if topic %}
       <div id="email-preview-ref"><strong>Ref:</strong>{{ topic }}</div>
       {% endif %}
-      <div id="email-preview-body" style="white-space:pre-wrap;margin:0 0 12px"></div>
       <div id="email-preview-audio" style="display:none;margin:0 0 12px">
         <strong>🎧 Voice Note:</strong> Click to listen
       </div>
@@ -197,6 +206,7 @@ thoughtful words, so far… (shoot for 42!)</h6>
     </div>
   </div>
 </div>
+</template>
 
 <!-- Button -->
 <div class="form-group">
@@ -238,6 +248,19 @@ thoughtful words, so far… (shoot for 42!)</h6>
       height: '500px',
       initialValue: `Dear {{ user }},\nThank you for...`
   });
+
+  var mdPreview = document.querySelector('#editor .toastui-editor-md-preview');
+  var contents = mdPreview && mdPreview.querySelector('.toastui-editor-contents');
+  var previewTemplate = document.getElementById('email-preview-template');
+  if (mdPreview && contents && previewTemplate) {
+    var chrome = previewTemplate.content.cloneNode(true);
+    var card = chrome.querySelector('.email-preview-card');
+    var audioSlot = chrome.querySelector('#email-preview-audio');
+    if (card && audioSlot) {
+      card.insertBefore(contents, audioSlot);
+      mdPreview.appendChild(chrome);
+    }
+  }
 
   var form = document.getElementById("thankyou-note-form");
   var submitBtn = document.getElementById("send-note-btn");
@@ -399,6 +422,9 @@ thoughtful words, so far… (shoot for 42!)</h6>
   var bylineInput = document.getElementById('byline');
 
   function applyEmailPreviewLayout() {
+    if (!preview) {
+      return;
+    }
     var id = layoutSelect.value;
     if (id !== 'compact' && id !== 'letter') {
       id = 'classic';
@@ -407,13 +433,11 @@ thoughtful words, so far… (shoot for 42!)</h6>
   }
 
   function updateEmailPreviewContent() {
-    var bodyEl = document.getElementById('email-preview-body');
     var bylineEl = document.getElementById('email-preview-byline');
     var audioEl = document.getElementById('email-preview-audio');
-    if (!bodyEl || !bylineEl || !audioEl) {
+    if (!bylineEl || !audioEl) {
       return;
     }
-    bodyEl.textContent = editor.getMarkdown();
     bylineEl.textContent = '--' + (bylineInput.value || '');
     var hasAudio = !!(audioBlob || (audioFileInput && audioFileInput.files.length));
     audioEl.style.display = hasAudio ? 'block' : 'none';

--- a/tests/test_email_templates.py
+++ b/tests/test_email_templates.py
@@ -1,0 +1,90 @@
+#  utf-8
+
+import os
+from io import open
+
+
+def _layouts():
+    """Load render helpers from myemail.py without importing Flask/MailerSend."""
+    root = os.path.dirname(os.path.dirname(__file__))
+    path = os.path.join(root, 'saythanks', 'myemail.py')
+    source = open(path, encoding='utf-8').read()
+    ns = {}
+    exec(
+        compile(
+            'import html\nfrom string import Template\n'
+            + source[
+                source.index('DEFAULT_TEMPLATE = '):
+                source.index('\ndef _get_note_url(')
+            ],
+            path,
+            'exec',
+        ),
+        ns,
+    )
+    return ns
+
+
+L = _layouts()
+
+
+def _html(template_id='classic', **kw):
+    args = {
+        'body': '<p>Thanks.</p>',
+        'byline': 'Ada',
+        'note_url': 'https://saythanks.io/note/abc',
+    }
+    args.update(kw)
+    return L['render_email_html'](template_id, **args)
+
+
+def test_unknown_id_falls_back_to_classic():
+    assert L['DEFAULT_TEMPLATE'] == 'classic'
+    for bad in (None, '', 'nope', '<script>'):
+        assert L['resolve_template_id'](bad) == 'classic'
+    html = _html('nope')
+    assert '=========' in html
+    assert 'A note of gratitude' not in html
+
+
+def test_each_layout_renders():
+    markers = {
+        'classic': '=========',
+        'compact': 'max-width:600px',
+        'letter': 'A note of gratitude',
+    }
+    assert tuple(markers) == L['TEMPLATE_IDS']
+    for template_id, marker in markers.items():
+        html = _html(template_id)
+        assert marker in html
+        assert '<p>Thanks.</p>' in html
+        assert '--Ada' in html
+
+
+def test_optional_slots():
+    bare = _html()
+    assert 'Ref:' not in bare
+    assert 'Voice Note' not in bare
+    assert 'Ref:' not in _html(topic='   ')
+    audio = (
+        '<div><strong>Voice Note:</strong> '
+        '<a href="https://a.webm">x</a></div>'
+    )
+    filled = _html(topic='toDo', audio_html=audio)
+    assert '<strong>Ref:</strong> about toDo' in filled
+    assert 'Voice Note:' in filled
+
+
+def test_substitution_is_safe():
+    html = _html(
+        body='Save $5 and {x}',
+        byline='A <b>b</b>',
+        topic='c <d>',
+        note_url='https://x.test/?a=1&b="y"',
+    )
+    assert 'Save $5 and {x}' in html
+    assert '<b>' not in html
+    assert '<d>' not in html
+    assert '--A &lt;b&gt;b&lt;/b&gt;' in html
+    assert 'about c &lt;d&gt;' in html
+    assert 'href="https://x.test/?a=1&amp;b=&quot;y&quot;"' in html

--- a/tests/test_submit_note_template.py
+++ b/tests/test_submit_note_template.py
@@ -78,6 +78,32 @@ def test_submit_button_does_not_shadow_native_form_submit():
     assert 'id="send-note-btn"' in template
     assert 'document.getElementById("send-note-btn")' in template
 
+
+def test_email_template_select_defaults_to_classic():
+    """Senders pick a predefined email layout; Classic is the default."""
+    template = _read_template()
+
+    assert 'name="email_template"' in template
+    assert 'id="email-template"' in template
+    assert 'value="classic" selected' in template
+    assert 'value="compact"' in template
+    assert 'value="letter"' in template
+    assert 'value="compact" selected' not in template
+    assert 'value="letter" selected' not in template
+
+
+def test_email_layout_preview_follows_the_select():
+    """The form preview must restyle when Email layout changes."""
+    template = _read_template()
+
+    assert 'id="email-preview"' in template
+    assert 'email-preview--classic' in template
+    assert 'email-preview--' in template
+    assert "preview.className = 'email-preview email-preview--' + id" in template
+    assert 'id="email-preview-ref"' in template
+    assert '### Ref:' not in template
+
+
 def test_no_stale_submit_id_selector_in_static_assets():
     """No CSS/JS asset may still target the removed #submit id.
     Equivalent of running run a 

--- a/tests/test_submit_note_template.py
+++ b/tests/test_submit_note_template.py
@@ -93,15 +93,25 @@ def test_email_template_select_defaults_to_classic():
 
 
 def test_email_layout_preview_follows_the_select():
-    """The form preview must restyle when Email layout changes."""
+    """Email chrome is in the Toast UI Preview tab."""
     template = _read_template()
 
+    assert 'id="email-preview-template"' in template
     assert 'id="email-preview"' in template
+    assert (
+        "document.querySelector('#editor .toastui-editor-md-preview')"
+        in template
+    )
+    assert "mdPreview.querySelector('.toastui-editor-contents')" in template
+    assert 'card.insertBefore(contents, audioSlot)' in template
     assert 'email-preview--classic' in template
     assert 'email-preview--' in template
     assert "preview.className = 'email-preview email-preview--' + id" in template
     assert 'id="email-preview-ref"' in template
     assert '### Ref:' not in template
+    assert 'id="email-preview-body"' not in template
+    assert 'bodyEl.textContent = editor.getMarkdown()' not in template
+    assert 'class="email-preview-label"' not in template
 
 
 def test_no_stale_submit_id_selector_in_static_assets():


### PR DESCRIPTION
I was able to implement 3 templates for emals the user can choose to send - with a live preview.

Implemented test suite.

Updated README with recent-changes bullet point.

Fixed #497 

Check (put an 'x' between the square brackets) everything which applies:

- [x] I have added the issue number for which this pull request is created.

@Pavithratrdev, please let me know about this update.
