### PR TITLE
fix: enforce configurable 30-second limit on audio recordings

### DIFF
--- a/saythanks/core.py
+++ b/saythanks/core.py
@@ -134,6 +134,7 @@ app.jinja_env.filters['strip_html'] = strip_html
 
 QRcode(app)
 app.secret_key = os.environ.get('APP_SECRET', 'CHANGEME')
+app.config['MAX_RECORDING_TIME'] = int(os.environ.get('MAX_RECORDING_TIME', 30))
 app.debug = True
 
 # Flask-Common.
@@ -357,11 +358,15 @@ def display_submit_note(inbox_id, topic):
     display_topic = ""
     if raw_topic:
         display_topic = " about " + raw_topic
+        
+    max_recording_time = app.config.get('MAX_RECORDING_TIME', 30)
+    
     return render_template(
         'submit_note.htm.j2',
         user=inbox_id,
         topic=display_topic,
-        fake_name=fake_name)
+        fake_name=fake_name,
+        max_recording_time=max_recording_time)
 
 
 @app.route('/note/<uuid>', methods=['GET'])

--- a/saythanks/templates/submit_note.htm.j2
+++ b/saythanks/templates/submit_note.htm.j2
@@ -230,6 +230,8 @@ thoughtful words, so far… (shoot for 42!)</h6>
   let recorder;
   let audioBlob;
   let mediaStream;
+  let recordingTimeout;
+  const maxRecordingTime = {{ max_recording_time | default(30) }} * 1000;
 
   const recordBtn = document.getElementById('recordBtn');
   const audioPreview = document.getElementById('audioPreview');
@@ -253,8 +255,27 @@ thoughtful words, so far… (shoot for 42!)</h6>
     }
 
     const selectedFile = audioFileInput.files[0];
-    audioBlob = selectedFile;
-    showAudioPreview(selectedFile, selectedFile.name);
+    
+    // Create an audio element to measure the duration of the uploaded file
+    const audioObj = new Audio(URL.createObjectURL(selectedFile));
+    audioObj.onloadedmetadata = () => {
+      const durationSecs = audioObj.duration;
+      if (durationSecs > (maxRecordingTime / 1000)) {
+        recordingStatus.innerText = 
+          `Warning: Voice note is ${Math.round(durationSecs)}s long. ` +
+          `It exceeds the ${maxRecordingTime / 1000}s limit. ` + 
+          `Unable to submit.`;
+        recordingStatus.style.color = "red";
+        document.getElementById("send-note-btn").disabled = true;
+        audioPreview.style.display = 'none';
+        audioBlob = null;
+      } else {
+        recordingStatus.style.color = "";
+        document.getElementById("send-note-btn").disabled = false;
+        audioBlob = selectedFile;
+        showAudioPreview(selectedFile, selectedFile.name);
+      }
+    };
   });
 
   recordBtn.addEventListener('click', async () => {
@@ -303,8 +324,23 @@ thoughtful words, so far… (shoot for 42!)</h6>
 
         recorder.start();
         recording = true;
+        
+        // Re-enable submit button if disabled by bad file upload earlier
+        document.getElementById("send-note-btn").disabled = false;
+        recordingStatus.style.color = "";
         recordBtn.innerText = '🛑 Stop Recording';
-        recordingStatus.innerText = 'Recording...';
+        recordingStatus.innerText = 
+          `Recording... (Max ${maxRecordingTime / 1000}s)`;
+        
+        recordingTimeout = setTimeout(() => {
+          if (recording) {
+            recorder.stop();
+            recording = false;
+            recordBtn.innerText = '🗣️ Say Something!';
+            recordingStatus.innerText = 
+              'Time limit reached. Voice note ready to submit.';
+          }
+        }, maxRecordingTime + 800); // 800ms buffer guarantees it crosses 30.0s
       } catch (err) {
         alert('Microphone access denied or not supported on this device. Use the audio picker to attach a voice note instead.');
         console.error(err);
@@ -313,6 +349,7 @@ thoughtful words, so far… (shoot for 42!)</h6>
       recorder.stop();
       recording = false;
       recordBtn.innerText = '🗣️ Say Something!';
+      clearTimeout(recordingTimeout);
     }
   });
 


### PR DESCRIPTION
Resolves Issue #507

Overview This PR implements a strict, configurable time limit (defaulting to 30 seconds) on all voice note submissions, addressing the technical improvement requested in #507. The limit is enforced across both live in-browser recordings and manually uploaded audio files.

Key Changes:

Backend Configuration (core.py): Added MAX_RECORDING_TIME to the application config. The server now securely reads this value from environment variables (defaulting to 30), making the limit easily configurable by administrators without needing to alter frontend code.

Jinja Template Injection: Safely passed the max_recording_time variable from core.py into submit_note.htm.j2 so the JavaScript is aware of the current environment limit.

Live Recording Timeout: Implemented a setTimeout function in the frontend that acts as an alarm clock. If a user clicks "Say Something!" and does not manually stop the recording before the limit is reached, the UI automatically cuts the microphone off. (Note: Added an 800ms UI buffer to the timeout to guarantee the browser's audio encoder consistently rounds the display exactly to 0:30 on the screen).

File Upload Validation: Added a metadata check for users uploading pre-recorded .webm or .m4a files via the mobile picker. If the uploaded audio file's duration exceeds the configurable limit, it throws a red UI warning and forcefully disables the "Send Note" button to prevent submission.

Formatting: Ensured all modified frontend lines strictly adhere to the < 80 column formatting rule.
Testing:

Verified that live recordings automatically stop and lock exactly at 0:30.
Verified that attempting to upload an audio file longer than 30 seconds disables the submit button.
Verified that the submit button properly re-enables when a valid recording/file replaces an invalid one.

OUTPUT AFTER THE PATCH:
<img width="362" height="760" alt="WhatsApp Image 2026-08-17 at 15 41 11" src="https://github.com/user-attachments/assets/e2cd3dcc-2f1a-4796-8f33-22405d422a8d" />

<img width="370" height="760" alt="WhatsApp Image 2026-08-17 at 15 41 09" src="https://github.com/user-attachments/assets/a67cee07-7c5b-453b-9c1c-6b83e3187642" />

