### PR TITLE
fix: correctly route follow-up emails to inbox owner instead of logged-in user

### DIFF
--- a/saythanks/core.py
+++ b/saythanks/core.py
@@ -444,10 +444,8 @@ def submit_note(inbox_id, topic):
     body = request.form['body']
     content_type = request.form['content-type']
     byline = Markup(request.form['byline']).striptags()
-    if session:
-        email_address = session['profile']['email']
-    else:
-        email_address = storage.Inbox.get_email(inbox_db.slug)
+    # Always send the email to the owner of the inbox, not the logged-in user
+    email_address = storage.Inbox.get_email(inbox_db.slug)
 
 
     # If the user chooses to send an HTML email,


### PR DESCRIPTION
### Description
This PR fixes a major logic bug in the `submit_note` function where email notifications were being incorrectly routed if the sender was currently logged in to SayThanks.

**The Bug:**
If a user is logged in and submits a note to someone else's inbox, the `submit_note` function mistakenly fetched the sender's own email from their `session` cookies instead of fetching the inbox owner's email from the database. This caused the "You received a note!" email to be delivered to the sender's own email address.

**The Fix:**
I completely removed the `if session:` fallback. The `email_address` variable is now strictly assigned to `storage.Inbox.get_email(inbox_db.slug)` regardless of session state. This mathematically guarantees that email notifications are always routed to the true owner of the inbox, perfectly fixing the issue.

### How has this been tested?
Because the local environment doesn't send physical emails without a `MAILERSEND_API_KEY`, I tested the exact routing logic locally to verify the fix:

1. I temporarily injected a print statement into `core.py` to output the `email_address` variable right before the email is sent.
    
<img width="1030" height="263" alt="Screenshot 2026-08-24 122809" src="https://github.com/user-attachments/assets/ae329471-9d63-48d1-85e7-4588c556cab4" />

2. I logged into the app via Auth0 using my personal account.

3. While logged in to a secondary test account, I navigated to my main inbox and submitted a Thank You note.

4. I checked the Docker logs, and verified that the `email_address` correctly printed out the **inbox owner's email**, proving that the app successfully ignored my logged-in session cookies.

<img width="980" height="87" alt="Screenshot 2026-08-24 122734" src="https://github.com/user-attachments/assets/ea3e8ac5-a3c1-4463-a4d7-7b8176508a47" />


### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
