### PR TITLE
fix: pin flask and mailersend in requirements.txt, update env templates (#516)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,7 +10,7 @@ To run the project, you need to set the following environment variables:
 - DATABASE_URL
 - SENTRY_DSN
 - AUTH0_DOMAIN
-- AUTH0_JWT_TOKEN
+- AUTH0_JWT_V2_TOKEN
 - AUTH0_CLIENT_ID
 - AUTH0_CLIENT_SECRET
 - AUTH0_CALLBACK_URL

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,7 +6,7 @@ See [setup file](docs/saythanks_development.md)
 
 To run the project, you need to set the following environment variables:
 
-- SENDGRID_API_KEY
+- MAILERSEND_API_KEY
 - DATABASE_URL
 - SENTRY_DSN
 - AUTH0_DOMAIN

--- a/conf_template/site.env
+++ b/conf_template/site.env
@@ -1,5 +1,5 @@
 DATABASE_URL='postgresql://user-name:strong-password@your-IP-addr/saythanks'
-SENDGRID_API_KEY=''
+MAILERSEND_API_KEY=''
 AUTH0_CLIENT_ID=''
 AUTH0_CLIENT_SECRET=''
 AUTH0_CALLBACK_URL='http://localhost:5000/callback'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ crayons
 dateparser
 docopt
 flake8
-flask
+flask<2.3
 flask-qrcode
 gunicorn
 humanize
@@ -35,7 +35,7 @@ raven
 regex
 requests
 ruamel.yaml
-mailersend
+mailersend==0.6.0
 six
 sqlalchemy
 tablib

--- a/sample.env
+++ b/sample.env
@@ -1,9 +1,10 @@
 # Make a copy of this file and save it as .env and change the values accordingly 
 
-SENDGRID_API_KEY=YOUR_SENDGRID_API_KEY
+MAILERSEND_API_KEY=YOUR_MAILERSEND_API_KEY
 AUTH0_DOMAIN=YOUR_AUTH_DOMAIN
 AUTH0_JWT_V2_TOKEN=YOUR_JWT_TOKEN
 AUTH0_CLIENT_ID=YOUR_CLIENT_ID
+AUTH0_CLIENT_SECRET=YOUR_AUTH0_CLIENT_SECRET
 DATABASE_URL="postgresql://user:pwd@server_ip/database_name"
 AUTH0_CALLBACK_URL='http://localhost:5000/callback'
 FLASK_APP=core

--- a/saythanks/core.py
+++ b/saythanks/core.py
@@ -19,7 +19,8 @@ from .logging_config import configure_logging
 
 from functools import wraps
 from flask import Flask, request, session, render_template, url_for
-from flask import abort, redirect, Markup, make_response
+from flask import abort, redirect, make_response
+from markupsafe import Markup
 from flask import send_from_directory
 from flask_common import Common
 from names import get_full_name


### PR DESCRIPTION
Resolves #516

### Summary
Following a fresh installation, \pip install -r requirements.txt\ installed unpinned versions of \lask\ (Flask 3.x) and \mailersend\ (MailerSend 2.x), which resulted in runtime \ImportError\ exceptions on boot:
1. \ImportError: cannot import name 'Markup' from 'flask'\ (due to removal in Flask 2.3+).
2. \ImportError: cannot import name 'emails' from 'mailersend'\ (due to SDK architectural rewrite in MailerSend 2.0.0).

Additionally, legacy references to \SENDGRID_API_KEY\ remained in template configuration files, causing drift from the MailerSend provider implementation.

### Key Changes
- **\equirements.txt\**:
  - Pinned \lask<2.3\ to guarantee stability with existing Flask extensions.
  - Pinned \mailersend==0.6.0\ to restore compatibility with \saythanks/myemail.py\ (\emails.NewEmail\ interface).
- **\saythanks/core.py\**:
  - Updated \Markup\ import to import from \markupsafe\ directly, ensuring forward compatibility across Flask versions.
- **Environment Templates**:
  - Updated \conf_template/site.env\, \sample.env\, and \DEVELOPMENT.md\ to reference \MAILERSEND_API_KEY\ instead of \SENDGRID_API_KEY\.
  - Added missing \AUTH0_CLIENT_SECRET\ to \sample.env\.

### Verification
- Verified all Python modules compile cleanly (\python -m py_compile\).
- Confirmed \site.env\ and \sample.env\ accurately reflect the environment variables read by the application.