### PR TITLE
Use a single word-count display on the thank-you form

### DIFF
--- a/saythanks/templates/submit_note.htm.j2
+++ b/saythanks/templates/submit_note.htm.j2
@@ -11,10 +11,6 @@
         color: red;
         font-weight: bold;
       }
-      #counter1 {
-        color: red;
-        font-weight: bold;
-      }
       /* Set font size and fixed font family for Toast UI Editor content */
      .toastui-editor-defaultUI .toastui-editor-contents,
      .toastui-editor-defaultUI .toastui-editor-md-preview-content,
@@ -101,8 +97,6 @@ thoughtful words, so far… (shoot for 42!)</h6>
   <p id="recordingStatus" style="color: green; font-weight: bold;"></p>
 </div>
 
-<h6>You have written <strong><span id="counter1">0</span></strong>
-thoughtful words, so far… (shoot for 42!)</h6>
 <!-- Text input-->
 <div class="form-group">
   <label class="col-md-4 control-label" for="byline">
@@ -146,7 +140,6 @@ thoughtful words, so far… (shoot for 42!)</h6>
     return count;
   }
   var counter = document.getElementById("counter");
-  var counter1 = document.getElementById("counter1");
 
   var textArea = document.getElementById("editor");
   const editor = new toastui.Editor({
@@ -396,10 +389,7 @@ thoughtful words, so far… (shoot for 42!)</h6>
   function updateWordCounters() {
     const count = wordCount(editor.getMarkdown());
     counter.innerText = count;
-    counter1.innerText = count;
-    const color = count > 42 ? "green" : "red";
-    counter.style.color = color;
-    counter1.style.color = color;
+    counter.style.color = count > 42 ? "green" : "red";
   }
 
   editor.on('change', () => {


### PR DESCRIPTION
## Summary
The thank-you note form showed the same live word count twice (`#counter` and `#counter1`) and kept two DOM references in sync.

This keeps a single `#counter` element above the editor and removes the duplicate heading, CSS, and JavaScript updates.

## Motivation
Requested in #556: two counters were pointing at the same value and are not needed.

## Implementation
- Remove the second `h6` / `#counter1` markup.
- Remove unused `#counter1` styles.
- Drop the extra `getElementById` and the second write in `updateWordCounters()`.

Word-count behavior is unchanged: still computed from `editor.getMarkdown()` and still turns green after 42 words.

## Testing
- Confirmed `counter1` no longer appears in `saythanks/templates/submit_note.htm.j2`.
- Reviewed the remaining `updateWordCounters()` path against the existing Toast UI `change` handler.
- No Python/backend change; existing tests do not cover this template JS.

Fixes #556