### PR TITLE
fix: resize Toast UI editor toolbar

### DIFF
--- a/saythanks/static/css/saythanks.css
+++ b/saythanks/static/css/saythanks.css
@@ -118,6 +118,8 @@ textarea {
   }
 
   #thankyou-note-form .toastui-editor-defaultUI-toolbar {
+    width: 100%;
+    box-sizing: border-box;
     overflow-x: auto;
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Toast UI Editor toolbar width so it properly fits the editor container.

## Changes

- Set the toolbar width to 100%
- Added `box-sizing: border-box`
- Preserved horizontal scrolling for smaller screens

Fixes #546